### PR TITLE
Consolidate daemon rpc tx pool interaction

### DIFF
--- a/src/cpp/daemon/py_monero_daemon.h
+++ b/src/cpp/daemon/py_monero_daemon.h
@@ -73,7 +73,7 @@ public:
   virtual PyMoneroKeyImageSpentStatus get_key_image_spent_status(std::string& key_image) { throw std::runtime_error("PyMoneroDaemon: not supported"); }
   virtual std::vector<PyMoneroKeyImageSpentStatus> get_key_image_spent_statuses(std::vector<std::string>& key_images) { throw std::runtime_error("PyMoneroDaemon: not supported"); }
   virtual std::vector<std::shared_ptr<monero::monero_output>> get_outputs(std::vector<monero::monero_output>& outputs) { throw std::runtime_error("PyMoneroDaemon: not supported"); }
-  virtual std::vector<std::shared_ptr<PyMoneroOutputHistogramEntry>> get_output_histogram(std::vector<uint64_t> amounts, int min_count, int max_count, bool is_unlocked, int recent_cutoff) { throw std::runtime_error("PyMoneroDaemon: not supported"); }
+  virtual std::vector<std::shared_ptr<PyMoneroOutputHistogramEntry>> get_output_histogram(const std::vector<uint64_t>& amounts, const boost::optional<int>& min_count, const boost::optional<int>& max_count, const boost::optional<bool>& is_unlocked, const boost::optional<int>& recent_cutoff) { throw std::runtime_error("PyMoneroDaemon: not supported"); }
   virtual std::vector<std::shared_ptr<PyMoneroOutputDistributionEntry>> get_output_distribution(std::vector<uint64_t> amounts) { throw std::runtime_error("PyMoneroDaemon: not supported"); }
   virtual std::vector<std::shared_ptr<PyMoneroOutputDistributionEntry>> get_output_distribution(std::vector<uint64_t> amounts, bool is_cumulative, uint64_t start_height, uint64_t end_height) { throw std::runtime_error("PyMoneroDaemon: not supported"); }
   virtual std::shared_ptr<PyMoneroDaemonInfo> get_info() { throw std::runtime_error("PyMoneroDaemon: not supported"); }

--- a/src/cpp/daemon/py_monero_daemon_model.cpp
+++ b/src/cpp/daemon/py_monero_daemon_model.cpp
@@ -274,7 +274,7 @@ void PyMoneroTx::from_property_tree(const boost::property_tree::ptree& node, con
     }
     else if (key == std::string("as_json")) as_json = it->second.data();
     else if (key == std::string("tx_json")) tx_json = it->second.data();
-    else if (key == std::string("as_hex") || key == std::string("tx_blob")) tx->m_full_hex = it->second.data();
+    else if ((key == std::string("as_hex") || key == std::string("tx_blob")) && !it->second.data().empty()) tx->m_full_hex = it->second.data();
     else if (key == std::string("blob_size")) tx->m_size = it->second.get_value<uint64_t>();
     else if (key == std::string("weight")) tx->m_weight = it->second.get_value<uint64_t>();
     else if (key == std::string("fee")) tx->m_fee = it->second.get_value<uint64_t>();
@@ -320,19 +320,21 @@ void PyMoneroTx::from_property_tree(const boost::property_tree::ptree& node, con
       }
     }
     else if (key == std::string("max_used_block_height")) tx->m_max_used_block_height = it->second.get_value<uint64_t>();
-    else if (key == std::string("max_used_block_id_hash")) tx->m_max_used_block_hash = it->second.data();
-    else if (key == std::string("prunable_hash")) tx->m_prunable_hash = it->second.data();
-    else if (key == std::string("prunable_as_hex")) tx->m_prunable_hex = it->second.data();
-    else if (key == std::string("pruned_as_hex")) tx->m_pruned_hex = it->second.data();
+    else if (key == std::string("max_used_block_id_hash") && !it->second.data().empty()) tx->m_max_used_block_hash = it->second.data();
+    else if (key == std::string("prunable_hash") && !it->second.data().empty()) tx->m_prunable_hash = it->second.data();
+    else if (key == std::string("prunable_as_hex") && !it->second.data().empty()) tx->m_prunable_hex = it->second.data();
+    else if (key == std::string("pruned_as_hex") && !it->second.data().empty()) tx->m_pruned_hex = it->second.data();
   }
 
-  if (block != nullptr) {
+  bool is_confirmed = tx->m_is_confirmed != boost::none && tx->m_is_confirmed.get();
+
+  if (block != nullptr && is_confirmed) {
     block->m_txs.push_back(tx);
     tx->m_block = block;
   }
 
   // initialize remaining known fields
-  if (tx->m_is_confirmed) {
+  if (is_confirmed) {
     tx->m_relay = true;
     tx->m_is_relayed = true;
     tx->m_is_failed = false;
@@ -358,7 +360,7 @@ void PyMoneroTx::from_property_tree(const boost::property_tree::ptree& node, con
     PyMoneroTx::from_property_tree(n, tx);
   }
 
-  if (tx->m_is_relayed != true) tx->m_last_relayed_timestamp = boost::none;
+  if (tx->m_is_relayed != boost::none && !tx->m_is_relayed.get()) tx->m_last_relayed_timestamp = boost::none;
 }
 
 void PyMoneroTx::from_property_tree(const boost::property_tree::ptree& node, std::vector<std::shared_ptr<monero::monero_tx>>& txs) {
@@ -649,7 +651,7 @@ void PyMoneroOutputHistogramEntry::from_property_tree(const boost::property_tree
 
       for(boost::property_tree::ptree::const_iterator it2 = node2.begin(); it2 != node2.end(); ++it2) {
         auto entry = std::make_shared<PyMoneroOutputHistogramEntry>();
-        from_property_tree(node2, entry);
+        from_property_tree(it2->second, entry);
         entries.push_back(entry);
       }
     }

--- a/src/cpp/daemon/py_monero_daemon_model.h
+++ b/src/cpp/daemon/py_monero_daemon_model.h
@@ -615,7 +615,7 @@ public:
   boost::optional<bool> m_is_unlocked;
   boost::optional<int> m_recent_cutoff;
 
-  PyMoneroGetOutputHistrogramParams(const std::vector<uint64_t> &amounts, int min_count, int max_count, bool is_unlocked, int recent_cutoff) {
+  PyMoneroGetOutputHistrogramParams(const std::vector<uint64_t>& amounts, const boost::optional<int>& min_count, const boost::optional<int>& max_count, const boost::optional<bool>& is_unlocked, const boost::optional<int>& recent_cutoff) {
     m_amounts = amounts;
     m_min_count = min_count;
     m_max_count = max_count;

--- a/src/cpp/daemon/py_monero_daemon_rpc.cpp
+++ b/src/cpp/daemon/py_monero_daemon_rpc.cpp
@@ -356,7 +356,17 @@ std::vector<std::shared_ptr<monero::monero_tx>> PyMoneroDaemonRpc::get_txs(const
 }
 
 std::vector<std::string> PyMoneroDaemonRpc::get_tx_hexes(const std::vector<std::string>& tx_hashes, bool prune) {
-  throw std::runtime_error("PyMoneroDaemon: not implemented");
+  std::vector<std::string> hexes;
+  for(const auto& tx : get_txs(tx_hashes, prune)) {
+    // tx may be pruned regardless of configuration
+    if (tx->m_pruned_hex == boost::none) {
+      if (tx->m_full_hex == boost::none) throw std::runtime_error("Tx has no hex");
+      hexes.push_back(tx->m_full_hex.get());
+    } else {
+      hexes.push_back(tx->m_pruned_hex.get());
+    }
+  }
+  return hexes;
 }
 
 std::shared_ptr<PyMoneroMinerTxSum> PyMoneroDaemonRpc::get_miner_tx_sum(uint64_t height, uint64_t num_blocks) {
@@ -486,7 +496,7 @@ std::vector<std::shared_ptr<monero::monero_output>> PyMoneroDaemonRpc::get_outpu
   throw std::runtime_error("PyMoneroDaemonRpc::get_outputs(): not implemented");
 }
 
-std::vector<std::shared_ptr<PyMoneroOutputHistogramEntry>> PyMoneroDaemonRpc::get_output_histogram(std::vector<uint64_t> amounts, int min_count, int max_count, bool is_unlocked, int recent_cutoff) {
+std::vector<std::shared_ptr<PyMoneroOutputHistogramEntry>> PyMoneroDaemonRpc::get_output_histogram(const std::vector<uint64_t>& amounts, const boost::optional<int>& min_count, const boost::optional<int>& max_count, const boost::optional<bool>& is_unlocked, const boost::optional<int>& recent_cutoff) {
   auto params = std::make_shared<PyMoneroGetOutputHistrogramParams>(amounts, min_count, max_count, is_unlocked, recent_cutoff);
   PyMoneroJsonRequest request("get_output_histogram", params);
   std::shared_ptr<PyMoneroJsonResponse> response = m_rpc->send_json_request(request);

--- a/src/cpp/daemon/py_monero_daemon_rpc.h
+++ b/src/cpp/daemon/py_monero_daemon_rpc.h
@@ -76,7 +76,7 @@ public:
   void flush_tx_pool(const std::string &hash) override;
   std::vector<PyMoneroKeyImageSpentStatus> get_key_image_spent_statuses(std::vector<std::string>& key_images) override;
   std::vector<std::shared_ptr<monero::monero_output>> get_outputs(std::vector<monero::monero_output>& outputs) override;
-  std::vector<std::shared_ptr<PyMoneroOutputHistogramEntry>> get_output_histogram(std::vector<uint64_t> amounts, int min_count, int max_count, bool is_unlocked, int recent_cutoff) override;
+  std::vector<std::shared_ptr<PyMoneroOutputHistogramEntry>> get_output_histogram(const std::vector<uint64_t>& amounts, const boost::optional<int>& min_count, const boost::optional<int>& max_count, const boost::optional<bool>& is_unlocked, const boost::optional<int>& recent_cutoff) override;
   std::shared_ptr<PyMoneroDaemonInfo> get_info() override;
   std::shared_ptr<PyMoneroDaemonSyncInfo> get_sync_info() override;
   std::shared_ptr<PyMoneroHardForkInfo> get_hard_fork_info() override;

--- a/src/cpp/py_monero.cpp
+++ b/src/cpp/py_monero.cpp
@@ -1445,7 +1445,7 @@ PYBIND11_MODULE(monero, m) {
     .def("get_outputs", [](PyMoneroDaemon& self, std::vector<monero::monero_output>& outputs) {
       MONERO_CATCH_AND_RETHROW(self.get_outputs(outputs));
     }, py::arg("outputs"))
-    .def("get_output_histogram", [](PyMoneroDaemon& self, std::vector<uint64_t>& amounts, int min_count, int max_count, bool is_unlocked, int recent_cutoff) {
+    .def("get_output_histogram", [](PyMoneroDaemon& self, const std::vector<uint64_t>& amounts, const boost::optional<int>& min_count, const boost::optional<int>& max_count, const boost::optional<bool>& is_unlocked, const boost::optional<int>& recent_cutoff) {
       MONERO_CATCH_AND_RETHROW(self.get_output_histogram(amounts, min_count, max_count, is_unlocked, recent_cutoff));
     }, py::arg("amounts"), py::arg("min_count"), py::arg("max_count"), py::arg("is_unlocked"), py::arg("recent_cutoff"))
     .def("get_output_distribution", [](PyMoneroDaemon& self, std::vector<uint64_t>& amounts) {

--- a/src/python/monero_daemon.pyi
+++ b/src/python/monero_daemon.pyi
@@ -324,17 +324,17 @@ class MoneroDaemon:
         :return list[MoneroOutputDistributionEntry]: output distribution entries meeting the parameters
         """
         ...
-    def get_output_histogram(self, amounts: list[int], min_count: int, max_count: int, is_unlocked: bool, recent_cutoff: int) -> list[MoneroOutputHistogramEntry]:
+    def get_output_histogram(self, amounts: list[int], min_count: int | None, max_count: int | None, is_unlocked: bool | None, recent_cutoff: int | None) -> list[MoneroOutputHistogramEntry]:
         """
         Get a histogram of output amounts. For all amounts (possibly filtered by
         parameters), gives the number of outputs on the chain for that amount.
         RingCT outputs counts as 0 amount.
         
-        :param int amounts: are amounts of outputs to make the histogram with
-        :param int min_count: TODO
-        :param int max_count: TODO
-        :param bool is_unlocked: makes a histogram with outputs with the specified lock state
-        :param int recent_cutoff: TODO
+        :param list[int] amounts: are amounts of outputs to make the histogram with
+        :param int | None min_count: TODO
+        :param int | None max_count: TODO
+        :param bool | None is_unlocked: makes a histogram with outputs with the specified lock state
+        :param int | None recent_cutoff: TODO
         :return list[MoneroOutputHistogramEntry]: output histogram entries meeting the parameters
         """
         ...

--- a/tests/test_monero_daemon_rpc.py
+++ b/tests/test_monero_daemon_rpc.py
@@ -9,7 +9,8 @@ from monero import (
     MoneroDaemonListener, MoneroPeer, MoneroDaemonInfo, MoneroDaemonSyncInfo,
     MoneroHardForkInfo, MoneroAltChain, MoneroTx, MoneroSubmitTxResult,
     MoneroTxPoolStats, MoneroBan, MoneroTxConfig, MoneroDestination,
-    MoneroWalletRpc, MoneroRpcError
+    MoneroWalletRpc, MoneroRpcError, MoneroKeyImageSpentStatus,
+    MoneroOutputHistogramEntry, MoneroOutputDistributionEntry
 )
 from utils import (
     TestUtils as Utils, TestContext,
@@ -52,7 +53,7 @@ class TestMoneroDaemonRpc:
 
     #endregion
 
-    #region Tests
+    #region Non Relays Tests
 
     # Can get the daemon's version
     @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
@@ -176,7 +177,7 @@ class TestMoneroDaemonRpc:
         assert len(block.txs) == 0, f"No block tx expected, found: {len(block.txs)}"
 
     # Can get blocks by hash which includes transactions (binary)
-    #@pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
     @pytest.mark.skip(reason="Not implemented")
     def test_get_blocks_by_hash_binary(self) -> None:
         raise NotImplementedError("Not implemented")
@@ -285,7 +286,7 @@ class TestMoneroDaemonRpc:
         BlockUtils.test_get_blocks_range(daemon, end_height - num_blocks - 1, None, height, True, self.BINARY_BLOCK_CTX)
 
     # Can get block hashes (binary)
-    #@pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
     @pytest.mark.skip(reason="Binary request not implemented")
     def test_get_block_ids_binary(self) -> None:
         # get_hashes.bin
@@ -373,15 +374,164 @@ class TestMoneroDaemonRpc:
             e_msg: str = str(e)
             assert "Invalid transaction hash" == e_msg, e_msg
 
+    # Can get transactions by hashes that are in the transaction pool
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    def test_get_txs_by_hashes_in_pool(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
+        # wait for wallet's txs in the pool to clear to ensure reliable sync
+        Utils.WALLET_TX_TRACKER.wait_for_txs_to_clear_pool(wallet)
+
+        # submit txs to the pool but don't relay
+        tx_hashes: list[str] = []
+        i: int = 1
+        while i < 3:
+            tx: MoneroTx = TxUtils.get_unrelayed_tx(wallet, i)
+            assert tx.hash is not None
+            assert tx.full_hex is not None
+            assert len(tx.full_hex) > 0
+            result: MoneroSubmitTxResult = daemon.submit_tx_hex(tx.full_hex, True)
+            DaemonUtils.test_submit_tx_result_good(result)
+            assert result.is_relayed is False
+            tx_hashes.append(tx.hash)
+            i+=1
+
+        # fetch txs by hash
+        logger.info("Fetching txs...")
+        txs: list[MoneroTx] = daemon.get_txs(tx_hashes)
+        logger.info("Done")
+
+        # context for testing tx
+        ctx: TestContext = TestContext()
+        ctx.is_pruned = False
+        ctx.is_confirmed = False
+        ctx.from_get_tx_pool = False
+
+        # test fetched txs
+        assert len(tx_hashes) == len(txs)
+        for tx in txs:
+            TxUtils.test_tx(tx, ctx)
+
+        # clear txs from pool
+        daemon.flush_tx_pool(tx_hashes)
+        wallet.sync()
+
+    # Can get a transaction hex by hash with and without pruning
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    def test_get_tx_hex_by_hash(self, daemon: MoneroDaemonRpc) -> None:
+        # fetch transaction hashes to test
+        tx_hashes: list[str] = TxUtils.get_confirmed_tx_hashes(daemon)
+
+        # fetch each tx hex by hash with and without pruning
+        hexes: list[str | None] = []
+        hexes_pruned: list[str | None] = []
+        for tx_hash in tx_hashes:
+            hexes.append(daemon.get_tx_hex(tx_hash))
+            hexes_pruned.append(daemon.get_tx_hex(tx_hash, True))
+
+        # test results
+        assert len(hexes) == len(tx_hashes)
+        assert len(hexes_pruned) == len(tx_hashes)
+
+        for i, tx_hex in enumerate(hexes):
+            pruned_tx_hex: str | None = hexes_pruned[i]
+            assert tx_hex is not None
+            assert pruned_tx_hex is not None
+            assert len(pruned_tx_hex) > 0
+            # pruned hex is shorter
+            assert len(tx_hex) >= len(pruned_tx_hex)
+
+        # fetch invalid hash
+        try:
+            daemon.get_tx_hex("invalid tx hash")
+            raise Exception("Should have failed")
+        except Exception as e:
+            e_msg: str = str(e)
+            assert e_msg == "Invalid transaction hash", e_msg
+
+    # Can get transaction hexes by hashes with and without pruning
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    def test_get_tx_hexes_by_hashes(self, daemon: MoneroDaemonRpc) -> None:
+        # fetch transaction hashes to test
+        tx_hashes: list[str] = TxUtils.get_confirmed_tx_hashes(daemon)
+
+        # fetch tx hexes by hash with and without pruning
+        hexes: list[str] = daemon.get_tx_hexes(tx_hashes)
+        hexes_pruned: list[str] = daemon.get_tx_hexes(tx_hashes, True)
+
+        # test results
+        assert len(hexes) == len(tx_hashes)
+        assert len(hexes_pruned) == len(tx_hashes)
+        for i, tx_hex in enumerate(hexes):
+            pruned_tx_hex: str = hexes_pruned[i]
+            assert tx_hex is not None
+            assert pruned_tx_hex is not None
+            assert len(pruned_tx_hex) > 0
+            # pruned hex is shorter
+            assert len(tx_hex) >= len(pruned_tx_hex)
+
+        # fetch invalid hash
+        tx_hashes.append("invalid tx hash")
+        try:
+            daemon.get_tx_hexes(tx_hashes)
+            raise Exception("Should have failed")
+        except Exception as e:
+            e_msg: str = str(e)
+            assert e_msg == "Invalid transaction hash", e_msg
+
+    # Can get the miner tx sum
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    def test_get_miner_tx_sum(self, daemon: MoneroDaemonRpc) -> None:
+        tx_sum = daemon.get_miner_tx_sum(0, min(5000, daemon.get_height()))
+        DaemonUtils.test_miner_tx_sum(tx_sum, Utils.REGTEST)
+
+    # Can get fee estimate
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    def test_get_fee_estimate(self, daemon: MoneroDaemonRpc) -> None:
+        fee_estimate = daemon.get_fee_estimate()
+        GenUtils.test_unsigned_big_integer(fee_estimate.fee, True)
+        assert len(fee_estimate.fees) == 4, "Exptected 4 fees"
+        for fee in fee_estimate.fees:
+            GenUtils.test_unsigned_big_integer(fee, True)
+        GenUtils.test_unsigned_big_integer(fee_estimate.quantization_mask, True)
+
+    # Can get all transactions in the transaction pool
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    def test_get_txs_in_pool(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
+        Utils.WALLET_TX_TRACKER.wait_for_txs_to_clear_pool(wallet)
+
+        # submit tx to pool but don't relay
+        tx: MoneroTx = TxUtils.get_unrelayed_tx(wallet, 1)
+        assert tx.hash is not None
+        assert tx.full_hex is not None
+        result: MoneroSubmitTxResult = daemon.submit_tx_hex(tx.full_hex, True)
+        DaemonUtils.test_submit_tx_result_good(result)
+        assert result.is_relayed is False
+
+        # fetch txs in pool
+        txs: list[MoneroTx] = daemon.get_tx_pool()
+
+        # context for testing tx
+        ctx: TestContext = TestContext()
+        ctx.is_pruned = False
+        ctx.is_confirmed = False
+        ctx.from_get_tx_pool = True
+
+        # test txs
+        assert len(txs) > 0, "Test requires an unconfirmed tx in the tx pool"
+        for a_tx in txs:
+            TxUtils.test_tx(a_tx, ctx)
+
+        # flush the tx from the pool, gg
+        daemon.flush_tx_pool(tx.hash)
+        wallet.sync()
+
     # Can get transaction pool statistics
     @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
-    @pytest.mark.flaky(reruns=5, reruns_delay=5)
     def test_get_tx_pool_statistics(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
         Utils.WALLET_TX_TRACKER.wait_for_txs_to_clear_pool([wallet])
         tx_ids: list[str] = []
         try:
             # submit txs to the pool but don't relay
-            i = 1
+            i: int = 1
             while i < 3:
                 # submit tx hex
                 logger.debug(f"test_get_tx_pool_statistics: account {i}")
@@ -402,21 +552,176 @@ class TestMoneroDaemonRpc:
             # flush txs
             daemon.flush_tx_pool(tx_ids)
 
-    # Can get the miner tx sum
+    # Can flush all transactions from the pool
     @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
-    def test_get_miner_tx_sum(self, daemon: MoneroDaemonRpc) -> None:
-        tx_sum = daemon.get_miner_tx_sum(0, min(5000, daemon.get_height()))
-        DaemonUtils.test_miner_tx_sum(tx_sum, Utils.REGTEST)
+    def test_flush_txs_from_pool(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
+        Utils.WALLET_TX_TRACKER.wait_for_txs_to_clear_pool(wallet)
 
-    # Can get fee estimate
+        # preserve original transactions in the pool
+        tx_pool_before: list[MoneroTx] = daemon.get_tx_pool()
+
+        # submit txs to the pool but don't relay
+        i: int = 1
+        while i < 3:
+            tx: MoneroTx = TxUtils.get_unrelayed_tx(wallet, i)
+            assert tx.full_hex is not None
+            result: MoneroSubmitTxResult = daemon.submit_tx_hex(tx.full_hex, True)
+            DaemonUtils.test_submit_tx_result_good(result)
+            i += 1
+
+        assert len(tx_pool_before) + 2 == len(daemon.get_tx_pool())
+
+        # flush tx pool
+        daemon.flush_tx_pool()
+        assert len(daemon.get_tx_pool()) == 0
+
+        # re-submit original transactions
+        for tx in tx_pool_before:
+            assert tx.full_hex is not None
+            assert tx.is_relayed is not None
+            result: MoneroSubmitTxResult = daemon.submit_tx_hex(tx.full_hex, tx.is_relayed)
+
+        # pool is back to original state
+        assert len(tx_pool_before) == len(daemon.get_tx_pool())
+
+        # sync wallet for next test
+        wallet.sync()
+
+    # Can flush a transaction from the pool by hash
     @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
-    def test_get_fee_estimate(self, daemon: MoneroDaemonRpc) -> None:
-        fee_estimate = daemon.get_fee_estimate()
-        GenUtils.test_unsigned_big_integer(fee_estimate.fee, True)
-        assert len(fee_estimate.fees) == 4, "Exptected 4 fees"
-        for fee in fee_estimate.fees:
-            GenUtils.test_unsigned_big_integer(fee, True)
-        GenUtils.test_unsigned_big_integer(fee_estimate.quantization_mask, True)
+    def test_flush_tx_from_pool_by_hash(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
+        Utils.WALLET_TX_TRACKER.wait_for_txs_to_clear_pool(wallet)
+
+        # preserve original transactions in the pool
+        tx_pool_before: list[MoneroTx] = daemon.get_tx_pool()
+
+        # submit txs to the pool but don't relay
+        txs: list[MoneroTx] = []
+        i: int = 1
+        while i < 3:
+            tx: MoneroTx = TxUtils.get_unrelayed_tx(wallet, i)
+            assert tx.full_hex is not None
+            result: MoneroSubmitTxResult = daemon.submit_tx_hex(tx.full_hex, True)
+            DaemonUtils.test_submit_tx_result_good(result)
+            txs.append(tx)
+            i += 1
+
+        # remove each tx from the pool by hash and test
+        num_txs: int = len(txs)
+        for i, tx in enumerate(txs):
+            assert tx.hash is not None
+            # flush tx from pool
+            daemon.flush_tx_pool(tx.hash)
+
+            # test tx pool
+            pool_txs: list[MoneroTx] = daemon.get_tx_pool()
+            assert num_txs - i - 1 == len(pool_txs)
+
+        # pool is back to original state
+        assert len(tx_pool_before) == len(daemon.get_tx_pool())
+
+        # sync wallet for next test
+        wallet.sync()
+
+    # Can flush transactions from the pool by hashes
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    def test_flush_txs_from_pool_by_hashes(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
+        Utils.WALLET_TX_TRACKER.wait_for_txs_to_clear_pool(wallet)
+
+        # preserve original transactions in the pool
+        tx_pool_before: list[MoneroTx] = daemon.get_tx_pool()
+
+        # submit txs to the pool but don't relay
+        tx_hashes: list[str] = []
+        i: int = 1
+        while i < 3:
+            tx: MoneroTx = TxUtils.get_unrelayed_tx(wallet, i)
+            assert tx.hash is not None
+            assert tx.full_hex is not None
+            result: MoneroSubmitTxResult = daemon.submit_tx_hex(tx.full_hex, True)
+            DaemonUtils.test_submit_tx_result_good(result)
+            tx_hashes.append(tx.hash)
+            i += 1
+
+        assert len(tx_pool_before) + len(tx_hashes) == len(daemon.get_tx_pool())
+
+        # remove all txs by hashes
+        daemon.flush_tx_pool(tx_hashes)
+
+        # pool is back to original state
+        assert len(tx_pool_before) == len(daemon.get_tx_pool())
+        wallet.sync()
+
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    def test_get_spent_status_of_key_images(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
+        Utils.WALLET_TX_TRACKER.wait_for_txs_to_clear_pool(wallet)
+
+        # submit txs to the pool to collect key images then flush them
+        txs: list[MoneroTx] = []
+        i: int = 1
+        while i < 3:
+            tx: MoneroTx = TxUtils.get_unrelayed_tx(wallet, i)
+            assert tx.full_hex is not None
+            daemon.submit_tx_hex(tx.full_hex, True)
+            txs.append(tx)
+            i += 1
+
+        key_images: list[str] = []
+        tx_hashes: list[str] = []
+        for tx in txs:
+            assert tx.hash is not None
+            tx_hashes.append(tx.hash)
+
+        for tx in daemon.get_txs(tx_hashes):
+            for tx_input in tx.inputs:
+                assert tx_input.key_image is not None
+                assert tx_input.key_image.hex is not None
+                key_images.append(tx_input.key_image.hex)
+
+        daemon.flush_tx_pool(tx_hashes)
+
+        # key images are not spent
+        DaemonUtils.test_spent_statuses(daemon, key_images, MoneroKeyImageSpentStatus.NOT_SPENT)
+
+        # submit txs to the pool but don't relay
+        for tx in txs:
+            assert tx.full_hex is not None
+            daemon.submit_tx_hex(tx.full_hex, True)
+
+        # key images are in the tx pool
+        DaemonUtils.test_spent_statuses(daemon, key_images, MoneroKeyImageSpentStatus.TX_POOL)
+
+        # collect key images of confirmed txs
+        key_images = []
+        txs = DaemonUtils.get_confirmed_txs(daemon, 10)
+        for tx in txs:
+            for tx_input in tx.inputs:
+                assert tx_input.key_image is not None
+                assert tx_input.key_image.hex is not None
+                key_images.append(tx_input.key_image.hex)
+
+        # key images are all spent
+        DaemonUtils.test_spent_statuses(daemon, key_images, MoneroKeyImageSpentStatus.CONFIRMED)
+
+        # flush this test's txs from pool
+        daemon.flush_tx_pool(tx_hashes)
+
+    # Can get an output histogram (binary)
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    def test_get_output_histogram_binary(self, daemon: MoneroDaemonRpc) -> None:
+        entries: list[MoneroOutputHistogramEntry] = daemon.get_output_histogram([], None, None, None, None)
+        assert len(entries) > 0
+        for entry in entries:
+            DaemonUtils.test_output_histogram_entry(entry)
+
+    # Can get an output distribution (binary)
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    @pytest.mark.xfail(reason="TODO not implemented")
+    def test_get_output_distribution_binary(self, daemon: MoneroDaemonRpc) -> None:
+        amounts: list[int] = [0, 1, 10, 100, 1000, 10000, 100000, 1000000]
+        entries: list[MoneroOutputDistributionEntry] = daemon.get_output_distribution(amounts)
+        for entry in entries:
+            DaemonUtils.test_output_distribution_entry(entry)
 
     # Can get general information
     @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
@@ -732,7 +1037,7 @@ class TestMoneroDaemonRpc:
                 raise
 
     # Can be stopped
-    #@pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
     @pytest.mark.skip(reason="test is disabled to not interfere with other tests")
     def test_stop(self, daemon: MoneroDaemonRpc) -> None:
         # stop the daemon

--- a/tests/utils/blockchain_utils.py
+++ b/tests/utils/blockchain_utils.py
@@ -17,6 +17,13 @@ logger: logging.Logger = logging.getLogger("BlockchainUtils")
 class BlockchainUtils(ABC):
     """Blockchain utilities"""
 
+    CHECK_BLOCK_TIMEOUT_SECONDS: int = 5
+    """Timeout in seconds to check blockchain mining progress"""
+
+    @classmethod
+    def _sleep(cls) -> None:
+        sleep(cls.CHECK_BLOCK_TIMEOUT_SECONDS)
+
     @classmethod
     def get_height(cls) -> int:
         """
@@ -69,11 +76,11 @@ class BlockchainUtils(ABC):
             block = daemon.wait_for_next_block_header()
             assert block.height is not None
             current_height = block.height
-            sleep(5)
+            cls._sleep()
 
         if stop_mining:
             MiningUtils.stop_mining()
-            sleep(5)
+            cls._sleep()
             current_height = daemon.get_height()
 
         logger.info(f"[100%] Reached blockchain height: {current_height}")

--- a/tests/utils/daemon_utils.py
+++ b/tests/utils/daemon_utils.py
@@ -8,7 +8,9 @@ from monero import (
     MoneroAltChain, MoneroBan, MoneroMinerTxSum,
     MoneroTxPoolStats, MoneroBlockTemplate,
     MoneroDaemonUpdateCheckResult, MoneroDaemonUpdateDownloadResult,
-    MoneroNetworkType, MoneroRpcConnection
+    MoneroNetworkType, MoneroRpcConnection, MoneroSubmitTxResult,
+    MoneroKeyImageSpentStatus, MoneroDaemonRpc, MoneroTx,
+    MoneroBlock, MoneroOutputHistogramEntry, MoneroOutputDistributionEntry
 )
 
 from .gen_utils import GenUtils
@@ -328,5 +330,111 @@ class DaemonUtils(ABC):
                 assert result.download_path is not None
         else:
             assert result.download_path is None
+
+    @classmethod
+    def test_submit_tx_result_common(cls, result: MoneroSubmitTxResult) -> None:
+        assert result.is_good is not None
+        assert result.is_relayed is not None
+        assert result.is_double_spend is not None
+        assert result.is_fee_too_low is not None
+        assert result.is_mixin_too_low is not None
+        assert result.has_invalid_input is not None
+        assert result.has_invalid_output is not None
+        assert result.is_overspend is not None
+        assert result.is_too_big is not None
+        assert result.sanity_check_failed is not None
+        assert result.reason is None or len(result.reason) > 0
+
+    @classmethod
+    def test_submit_tx_result_good(cls, result: Optional[MoneroSubmitTxResult]) -> None:
+        assert result is not None
+        cls.test_submit_tx_result_common(result)
+        try:
+            # test good tx submission
+            assert result.is_double_spend is False, "tx submission is double spend."
+            assert result.is_fee_too_low is False, "fee is too low."
+            assert result.is_mixin_too_low is False, "mixin is too low."
+            assert result.has_invalid_input is False, "tx has invalid input."
+            assert result.has_invalid_output is False, "tx has invalid output."
+            assert result.has_too_few_outputs is False, "tx has too few outputs."
+            assert result.is_overspend is False, "tx is overspend."
+            assert result.is_too_big is False, "tx is too big."
+            assert result.sanity_check_failed is False, "tx sanity check failed."
+            # 0 credits
+            GenUtils.test_unsigned_big_integer(result.credits, False)
+            assert result.top_block_hash is None
+            assert result.is_tx_extra_too_big is False, "tx extra is too big."
+            assert result.is_good is True
+            assert result.is_nonzero_unlock_time is False, "tx has non-zero unlock time."
+        except Exception as e:
+            logger.warning(f"Submit result is not good: {e}")
+            raise
+
+    @classmethod
+    def test_submit_tx_result_double_spend(cls, result: Optional[MoneroSubmitTxResult]) -> None:
+        assert result is not None
+        cls.test_submit_tx_result_common(result)
+        assert result.is_good is False
+        assert result.is_double_spend is True
+        assert result.is_fee_too_low is False
+        assert result.is_mixin_too_low is False
+        assert result.has_invalid_input is False
+        assert result.has_invalid_output is False
+        assert result.is_overspend is False
+        assert result.is_too_big is False
+
+    @classmethod
+    def test_spent_statuses(cls, daemon: MoneroDaemonRpc, key_images: list[str], expected_status: MoneroKeyImageSpentStatus) -> None:
+        # test image
+        for key_image in key_images:
+            assert daemon.get_key_image_spent_status(key_image) == expected_status
+
+        # test array of images
+        statuses: list[MoneroKeyImageSpentStatus] = []
+        if len(key_images) > 0:
+            statuses = daemon.get_key_image_spent_statuses(key_images)
+
+        assert len(key_images) == len(statuses)
+        for status in statuses:
+            assert status == expected_status
+
+    @classmethod
+    def test_output_distribution_entry(cls, entry: Optional[MoneroOutputDistributionEntry]) -> None:
+        assert entry is not None
+        GenUtils.test_unsigned_big_integer(entry.amount)
+        assert entry.base is not None
+        assert entry.base >= 0
+        assert len(entry.distribution) > 0
+        assert entry.start_height is not None
+        assert entry.start_height >= 0
+
+    @classmethod
+    def test_output_histogram_entry(cls, entry: Optional[MoneroOutputHistogramEntry]) -> None:
+        assert entry is not None
+        GenUtils.test_unsigned_big_integer(entry.amount)
+        assert entry.num_instances is not None
+        assert entry.num_instances >= 0
+        assert entry.unlocked_instances is not None
+        assert entry.unlocked_instances >= 0
+        assert entry.recent_instances is not None
+        assert entry.recent_instances >= 0
+
+    @classmethod
+    def get_confirmed_txs(cls, daemon: MoneroDaemonRpc, num_txs: int) -> list[MoneroTx]:
+        txs: list[MoneroTx] = []
+        num_blocks_per_req: int = 50
+        start_idx: int = daemon.get_height() - num_blocks_per_req - 1
+
+        while start_idx >= 0:
+            blocks: list[MoneroBlock] = daemon.get_blocks_by_range(start_idx, start_idx + num_blocks_per_req)
+            for block in blocks:
+                for tx in block.txs:
+                    txs.append(tx)
+                    if len(txs) == num_txs:
+                        return txs
+
+            start_idx -= num_blocks_per_req
+
+        raise Exception(f"Could not get {num_txs} confirmed txs")
 
     #endregion

--- a/tests/utils/tx_utils.py
+++ b/tests/utils/tx_utils.py
@@ -555,7 +555,7 @@ class TxUtils(ABC):
                 assert tx.num_confirmations is not None
                 assert tx.num_confirmations > 0
         else:
-            assert tx.block is None
+            assert tx.block is None, f"Expected block tx to be null: {tx.block.serialize()}"
             assert tx.num_confirmations == 0
 
         # test in tx pool

--- a/tests/utils/wallet_tx_tracker.py
+++ b/tests/utils/wallet_tx_tracker.py
@@ -68,9 +68,10 @@ class WalletTxTracker:
             # get pending wallet tx hashes
             tx_hashes_wallet: set[str] = set()
             for i, wallet in enumerate(wallets):
-                logger.debug(f"Syncing wallet {i + 1}...")
                 result: MoneroSyncResult = wallet.sync()
-                logger.debug(f"Synced wallet {i + 1}, blocks fetched {result.num_blocks_fetched}")
+                assert result.num_blocks_fetched is not None
+                if result.num_blocks_fetched > 0:
+                    logger.debug(f"Synced wallet {i + 1}, blocks fetched {result.num_blocks_fetched}")
                 query = MoneroTxQuery()
                 query.in_tx_pool = True
                 pool_txs: list[MoneroTxWallet] = wallet.get_txs(query)
@@ -86,7 +87,6 @@ class WalletTxTracker:
                     else:
                         tx_hashes_wallet.add(tx.hash)
 
-            logger.debug(f"Found {len(tx_hashes_wallet)} wallet pending txs")
             # get pending txs to wait for
             tx_hashes_pool: set[str] = set()
             if clear_from_wallet:
@@ -112,8 +112,6 @@ class WalletTxTracker:
                     # stop mining if started
                     self._daemon.stop_mining()
                 break
-
-            logger.debug(f"Found {num_txs_in_pool} txs in pool")
 
             # log message and start mining if first iteration
             if is_first:
@@ -143,11 +141,12 @@ class WalletTxTracker:
         # sync wallets with the pool
         for i, wallet in enumerate(wallets):
             while wallet.get_height() < self._daemon.get_height():
-                logger.debug(f"Syncing wallet {i + 1} with the pool")
                 result = wallet.sync()
-                logger.debug(f"Synced wallet {i + 1} with the pool, fetched {result.num_blocks_fetched} blocks")
+                assert result.num_blocks_fetched is not None
+                if result.num_blocks_fetched > 0:
+                    logger.debug(f"Synced wallet {i + 1} with the pool, fetched {result.num_blocks_fetched} blocks")
 
-        msg = f"Cleared pending wallet transactions from {len(wallets)} wallets"
+        msg: str = f"Cleared pending wallet transactions from {len(wallets)} wallets"
         if not clear_from_wallet:
             msg = "Cleared pool pending wallet transactions"
         logger.debug(msg)


### PR DESCRIPTION
* Add daemon rpc tests `test_get_txs_by_hashes_in_pool`, `test_get_tx_hex_by_hash`, `test_get_tx_hexes_by_hashes`, `test_get_txs_in_pool`, `test_flush_txs_from_pool`,  `test_flush_tx_from_pool_by_hash`, `test_flush_txs_from_pool_by_hashes`, `test_get_spent_status_of_key_images`, `test_get_output_histogram_binary`, `test_get_output_distribution_binary`
* Fix `PyMoneroDaemonRpc::get_output_histogram`, `PyMoneroOutputHistogramEntry::from_property_tree`,
* Implement `PyMoneroDaemonRpc::get_tx_hexes`, `PyMoneroTx::from_property_tree`