### PR TITLE
Daemon txs relaying consolidation

### DIFF
--- a/src/cpp/daemon/py_monero_daemon_model.cpp
+++ b/src/cpp/daemon/py_monero_daemon_model.cpp
@@ -604,7 +604,7 @@ void PyMoneroSubmitTxResult::from_property_tree(const boost::property_tree::ptre
     else if (key == std::string("low_mixin")) result->m_is_mixin_too_low = it->second.get_value<bool>();
     else if (key == std::string("not_relayed")) result->m_is_relayed = !it->second.get_value<bool>();
     else if (key == std::string("overspend")) result->m_is_overspend = it->second.get_value<bool>();
-    else if (key == std::string("reason")) result->m_reason = it->second.data();
+    else if (key == std::string("reason") && !it->second.data().empty()) result->m_reason = it->second.data();
     else if (key == std::string("too_big")) result->m_is_too_big = it->second.get_value<bool>();
     else if (key == std::string("sanity_check_failed")) result->m_sanity_check_failed = it->second.get_value<bool>();
     else if (key == std::string("credits")) result->m_credits = it->second.get_value<uint64_t>();

--- a/tests/test_monero_daemon_rpc.py
+++ b/tests/test_monero_daemon_rpc.py
@@ -18,7 +18,8 @@ from utils import (
     AssertUtils, TxUtils,
     BlockUtils, GenUtils,
     DaemonUtils, WalletType,
-    IntegrationTestUtils
+    IntegrationTestUtils,
+    SubmitThenRelayTxTester
 )
 
 logger: logging.Logger = logging.getLogger("TestMoneroDaemonRpc")
@@ -834,6 +835,7 @@ class TestMoneroDaemonRpc:
         daemon.set_incoming_peer_limit(10)
 
     # Can notify listeners when a new block is added to the chain
+    @pytest.mark.skipif(Utils.TEST_NON_RELAYS is False, reason="TEST_NON_RELAYS disabled")
     @pytest.mark.skipif(Utils.LITE_MODE is True or Utils.TEST_NOTIFICATIONS is False, reason="TEST_NOTIFICATIONS disabled")
     def test_block_listener(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
         try:
@@ -1053,5 +1055,84 @@ class TestMoneroDaemonRpc:
         except Exception as e:
             e_msg: str = str(e)
             assert e_msg != "Should have thrown error", e_msg
+
+    #endregion
+
+    #region Relays Tests
+
+    # Can submit a tx in hex format to the pool and relay in one call
+    @pytest.mark.skipif(Utils.TEST_RELAYS is False, reason="TEST_RELAYS disabled")
+    @pytest.mark.skipif(Utils.LITE_MODE, reason="LITE_MODE enabled")
+    def test_submit_and_relay_tx_hex(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
+        # wait one time for wallet txs in the pool to clear
+        # TODO monero-project: update from pool does not prevent creating double spend tx
+        Utils.WALLET_TX_TRACKER.wait_for_txs_to_clear_pool(wallet)
+
+        # create 2 txs, the second will double spend outputs of first
+        #  TODO: this test requires tx to be from/to different accounts else
+        # the occlusion issue (#4500) causes the tx to not be recognized by the wallet at all
+        tx1: MoneroTx = TxUtils.get_unrelayed_tx(wallet, 2)
+        tx2: MoneroTx = TxUtils.get_unrelayed_tx(wallet, 2)
+
+        # submit and relay tx1
+        assert tx1.hash is not None
+        assert tx1.full_hex is not None
+        result: MoneroSubmitTxResult = daemon.submit_tx_hex(tx1.full_hex)
+        assert result.is_relayed is True
+        DaemonUtils.test_submit_tx_result_good(result)
+
+        # tx1 is in the pool
+        txs: list[MoneroTx] = daemon.get_tx_pool()
+        found: bool = False
+        for a_tx in txs:
+            assert a_tx.hash is not None
+            if a_tx.hash == tx1.hash:
+                assert a_tx.is_relayed is True
+                found = True
+                break
+
+        assert found, "Tx1 was not found after being submitted to the daemon's tx pool"
+
+        # tx1 is recognized by the wallet
+        wallet.sync()
+        wallet.get_tx(tx1.hash)
+
+        # submit and relay tx2 hex which double spends tx1
+        assert tx2.full_hex is not None
+        result = daemon.submit_tx_hex(tx2.full_hex)
+        assert result.is_relayed is True
+        DaemonUtils.test_submit_tx_result_double_spend(result)
+
+        # tx2 is not in the pool
+        txs = daemon.get_tx_pool()
+        found = False
+        for a_tx in txs:
+            assert a_tx.hash is not None
+            if a_tx.hash == tx2.hash:
+                found = True
+                break
+
+        assert not found, "Tx2 should not be in the pool because it double spends tx1 which is in the pool"
+
+    # Can submit a tx in hex format to the pool then relay
+    @pytest.mark.skipif(Utils.TEST_RELAYS is False, reason="TEST_RELAYS disabled")
+    @pytest.mark.skipif(Utils.LITE_MODE, reason="LITE_MODE enabled")
+    def test_submit_then_relay_tx_hex(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
+        Utils.WALLET_TX_TRACKER.wait_for_txs_to_clear_pool(wallet)
+        tx: MoneroTx = TxUtils.get_unrelayed_tx(wallet, 1)
+        tester: SubmitThenRelayTxTester = SubmitThenRelayTxTester(daemon, [tx])
+        tester.test()
+
+    # Can submit txs in hex format to the pool then relay
+    @pytest.mark.skipif(Utils.TEST_RELAYS is False, reason="TEST_RELAYS disabled")
+    @pytest.mark.skipif(Utils.LITE_MODE, reason="LITE_MODE enabled")
+    def test_submit_then_relay_tx_hexes(self, daemon: MoneroDaemonRpc, wallet: MoneroWalletRpc) -> None:
+        Utils.WALLET_TX_TRACKER.wait_for_txs_to_clear_pool(wallet)
+        txs: list[MoneroTx] = []
+        txs.append(TxUtils.get_unrelayed_tx(wallet, 1))
+        # TODO: accounts cannot be re-used across send tests else isRelayed is true; wallet needs to update?
+        txs.append(TxUtils.get_unrelayed_tx(wallet, 2))
+        tester: SubmitThenRelayTxTester = SubmitThenRelayTxTester(daemon, txs)
+        tester.test()
 
     #endregion

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -26,6 +26,7 @@ from .integration_test_utils import IntegrationTestUtils
 from .wallet_type import WalletType
 from .view_only_and_offline_wallet_tester import ViewOnlyAndOfflineWalletTester
 from .wallet_notification_collector import WalletNotificationCollector
+from .submit_then_relay_tx_tester import SubmitThenRelayTxTester
 
 __all__ = [
     'WalletUtils',
@@ -55,5 +56,6 @@ __all__ = [
     'IntegrationTestUtils',
     'WalletType',
     'ViewOnlyAndOfflineWalletTester',
-    'WalletNotificationCollector'
+    'WalletNotificationCollector',
+    'SubmitThenRelayTxTester'
 ]

--- a/tests/utils/submit_then_relay_tx_tester.py
+++ b/tests/utils/submit_then_relay_tx_tester.py
@@ -1,0 +1,109 @@
+
+from time import sleep
+
+from monero import (
+    MoneroDaemonRpc, MoneroTx,
+    MoneroSubmitTxResult
+)
+
+from .daemon_utils import DaemonUtils
+
+
+class SubmitThenRelayTxTester:
+    """Test submitting then relaying txs."""
+
+    daemon: MoneroDaemonRpc
+    """Daemon rpc test instance."""
+    txs: list[MoneroTx]
+    """Transactions to test."""
+
+    def __init__(self, daemon: MoneroDaemonRpc, txs: list[MoneroTx]) -> None:
+        """
+        Initialize a submit-then-relay-tx tester
+
+        :param MoneroDaemonRpc daemon: daemon rpc instance.
+        :param list[MoneroTx] txs: txs to test.
+        """
+        self.daemon = daemon
+        self.txs = txs
+
+    def is_tx_in_pool(self, tx_hash: str) -> bool:
+        """
+        Check if tx is in pool.
+
+        :param str tx_hash: the transaction's hash to check.
+        :returns bool: `True` if transaction was found in the pool.
+        """
+        pool_txs: list[MoneroTx] = self.daemon.get_tx_pool()
+        for a_tx in pool_txs:
+            assert a_tx.hash is not None
+            if a_tx.hash == tx_hash:
+                assert a_tx.is_relayed is False
+                return True
+
+        return False
+
+    def ensure_txs_relayed(self) -> None:
+        """
+        Ensure test transactions are relayed.
+        """
+        # ensure txs are relayed
+        pool_txs: list[MoneroTx] = self.daemon.get_tx_pool()
+        for tx in self.txs:
+            found: bool = False
+            for a_tx in pool_txs:
+                assert a_tx.hash is not None
+                if a_tx.hash == tx.hash:
+                    assert a_tx.is_relayed is True
+                    found = True
+                    break
+
+            assert found, "Tx was not found after being submitted to the daemon's tx pool"
+
+    def get_and_test_tx_hashes(self) -> list[str]:
+        """
+        Submit and get tx hashes without relaying.
+
+        :returns list[str]: list of non-relayed tx hashes.
+        """
+        tx_hashes: list[str] = []
+        for tx in self.txs:
+            assert tx.hash is not None
+            assert tx.full_hex is not None
+            tx_hashes.append(tx.hash)
+            result: MoneroSubmitTxResult = self.daemon.submit_tx_hex(tx.full_hex, True)
+            DaemonUtils.test_submit_tx_result_good(result)
+            assert result.is_relayed is False
+
+            # ensure tx is in pool
+            assert self.is_tx_in_pool(tx.hash), "Tx was not found after being submitted to the daemon's tx pool"
+
+            # fetch tx by hash and ensure not relayed
+            fetched_tx: MoneroTx | None = self.daemon.get_tx(tx.hash)
+            assert fetched_tx is not None
+            assert fetched_tx.is_relayed is False
+
+        return tx_hashes
+
+    def test(self) -> None:
+        """Start test"""
+        # submit txs hex but don't relay
+        tx_hashes: list[str] = self.get_and_test_tx_hashes()
+
+        # relay the txs
+        try:
+            if len(tx_hashes) == 1:
+                self.daemon.relay_tx_by_hash(tx_hashes[0])
+            else:
+                self.daemon.relay_txs_by_hash(tx_hashes)
+
+        except Exception:
+            # flush txs when relay fails to prevent double spends in other tests
+            self.daemon.flush_tx_pool(tx_hashes)
+            raise
+
+        # wait for txs to be relayed
+        # TODO (monero-project): all txs should be relayed: https://github.com/monero-project/monero/issues/8523
+
+        sleep(1)
+        self.ensure_txs_relayed()


### PR DESCRIPTION
* Add daemon rpc tests `test_submit_and_relay_tx_hex`, `test_submit_then_relay_tx_hex`, `test_submit_then_relay_tx_hexes`
* Fix `PyMoneroSubmitTxResult::from_property_tree`
* Implement test utility `SubmitThenRelayTxTester` for daemon rpc relays tests