### PR TITLE
Improve CI: build caching, self-contained packages, accurate deb deps

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -95,22 +99,28 @@ jobs:
             --build-arg THREADS=3 \
             -t monero-python:${{ matrix.name }}-${{ matrix.arch }} \
             -f Dockerfile.linux \
+            --cache-from type=gha,scope=${{ matrix.name }}-${{ matrix.arch }} \
+            --cache-to type=gha,mode=max,scope=${{ matrix.name }}-${{ matrix.arch }} \
             --load \
             .
 
       - name: Build monero-python
-        run: |
-          PLATFORM=${{ matrix.arch == 'amd64' && 'linux/amd64' ||
-                      matrix.arch == 'armhf' && 'linux/arm/v7' ||
-                      'linux/arm64' }}
-          PACKAGE_NAME="python3-monero_${{ github.run_id }}-1${{ matrix.name }}1_${{ matrix.arch }}"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: |
+            PLATFORM=${{ matrix.arch == 'amd64' && 'linux/amd64' ||
+                        matrix.arch == 'armhf' && 'linux/arm/v7' ||
+                        'linux/arm64' }}
+            PACKAGE_NAME="python3-monero_${{ github.run_id }}-1${{ matrix.name }}1_${{ matrix.arch }}"
 
-          docker run --rm \
-            --platform $PLATFORM \
-            -v $PWD:/monero-python -w /monero-python \
-            -e PACKAGE_NAME="${PACKAGE_NAME}" \
-            monero-python:${{ matrix.name }}-${{ matrix.arch }} \
-            bash -euxc "./docker/build.sh"
+            docker run --rm \
+              --platform $PLATFORM \
+              -v $PWD:/monero-python -w /monero-python \
+              -e PACKAGE_NAME="${PACKAGE_NAME}" \
+              monero-python:${{ matrix.name }}-${{ matrix.arch }} \
+              bash -euxc "./docker/build.sh"
 
       - name: Upload deb package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -4,22 +4,40 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   build:
-    name: ${{ matrix.os }} (arm64)
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15]
+        os: [macos-14, macos-15, macos-15-intel]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         submodules: recursive
+
+    - name: Determine monero submodule version
+      run: git submodule status --recursive > .monero-submodule-version
+
+    - name: Cache monero/monero-cpp build
+      id: cache-monero
+      uses: actions/cache@v4
+      with:
+        path: |
+          external/monero-cpp/external/monero-project/build
+          external/monero-cpp/build
+        key: monero-build-macos-${{ matrix.os }}-${{ hashFiles('.monero-submodule-version') }}
+        restore-keys: |
+          monero-build-macos-${{ matrix.os }}-
 
     - name: Install dependencies
       run: |
@@ -32,7 +50,12 @@ jobs:
       run: |
         pip3 install pybind11==2.13.6 pybind11-stubgen --break-system-packages
 
+    - name: Install delocate
+      run: |
+        pip3 install delocate --break-system-packages
+
     - name: Build monero
+      if: steps.cache-monero.outputs.cache-hit != 'true'
       run: |
         cd external/monero-cpp/external/monero-project
         mkdir -p build/release
@@ -42,6 +65,7 @@ jobs:
         cd ../../../../../../
 
     - name: Build monero-cpp
+      if: steps.cache-monero.outputs.cache-hit != 'true'
       run: |
         cd external/monero-cpp
         mkdir -p build
@@ -56,8 +80,12 @@ jobs:
         mkdir -p build
         python3 -m pip wheel . -w dist --no-build-isolation
 
+    - name: Repair wheel with delocate
+      run: |
+        delocate-wheel -w wheelhouse -v dist/*.whl
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: monero-${{ matrix.os }}
-        path: dist/*.whl
+        path: wheelhouse/*.whl

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   msys2-mingw64:
@@ -20,14 +24,34 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Determine monero submodule version
+        shell: bash
+        run: git submodule status --recursive > .monero-submodule-version
+
+      - name: Cache monero/monero-cpp build
+        id: cache-monero
+        uses: actions/cache@v4
+        with:
+          path: |
+            external/monero-cpp/external/monero-project/build
+            external/monero-cpp/build
+          key: monero-build-windows-${{ hashFiles('.monero-submodule-version') }}
+          restore-keys: |
+            monero-build-windows-
+
       - name: Setup Python 3.13
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
           architecture: 'x64'
 
+      - name: Install Python build dependencies
+        shell: bash
+        run: |
+          python -m pip install scikit-build-core delvewheel
+
       - name: Setup MSYS2 MINGW64
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           msystem: MINGW64
           update: true
@@ -49,25 +73,25 @@ jobs:
             wget
 
       - name: Install ICU v75.1
-        shell: msys2 {0}
         run: |
           wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-75.1-2-any.pkg.tar.zst
+          echo "bf57882d43efcdfd746463613ea982c69b64aa4ba9bed4cb24c02a81ad06c3a9  mingw-w64-x86_64-icu-75.1-2-any.pkg.tar.zst" | sha256sum -c
           pacman -U --noconfirm mingw-w64-x86_64-icu-75.1-2-any.pkg.tar.zst
 
       - name: Install boost v1.87.0
-        shell: msys2 {0}
         run: |
           wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-boost-1.87.0-3-any.pkg.tar.zst
+          echo "241919a5885a9270d0e0937e71cf5e146c2a8cabecc2714f09248350181cb1b6  mingw-w64-x86_64-boost-1.87.0-3-any.pkg.tar.zst" | sha256sum -c
           pacman -U --noconfirm mingw-w64-x86_64-boost-1.87.0-3-any.pkg.tar.zst
 
-      - name: Install pybind11 v2.13.1
-        shell: msys2 {0}
+      - name: Install pybind11 v2.13.6
         run: |
           wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-pybind11-2.13.6-2-any.pkg.tar.zst
+          echo "5b56ad87bc544336b2d51edb8bb0614f46542571362daf4d7e53bf23120175a1  mingw-w64-x86_64-pybind11-2.13.6-2-any.pkg.tar.zst" | sha256sum -c
           pacman -U --noconfirm mingw-w64-x86_64-pybind11-2.13.6-2-any.pkg.tar.zst
 
       - name: Build monero
-        shell: msys2 {0}
+        if: steps.cache-monero.outputs.cache-hit != 'true'
         run: |
           cd external/monero-cpp/external/monero-project
           mkdir -p build/release
@@ -84,7 +108,7 @@ jobs:
             make wallet cryptonote_protocol
 
       - name: Build monero-cpp
-        shell: msys2 {0}
+        if: steps.cache-monero.outputs.cache-hit != 'true'
         run: |
           cd external/monero-cpp
           mkdir -p build
@@ -92,25 +116,22 @@ jobs:
           cmake ..
           cmake --build .
 
-      - name: Build monero-python
-        shell: msys2 {0}
+      - name: Build wheel
         run: |
-          mkdir -p build
-          cd build
-          export WIN_PYTHON_EXE=$(cygpath -u "$PYTHON")
-          cmake .. -DPython3_EXECUTABLE="$WIN_PYTHON_EXE" \
-            -DPython3_FIND_STRATEGY=LOCATION \
-            -DPython3_FIND_REGISTRY=NEVER
-          cmake --build .
-          mkdir -p ../dist
-          cp *.pyd ../dist/monero.pyd
-          cd ../dist
-          ntldd -R *.pyd | grep mingw64 | awk '{print $3}' | while read -r line; do
-            cp "$(cygpath -u "$line")" .
-          done
+          export WIN_PYTHON_EXE=$(cygpath -u "$pythonLocation/python.exe")
+          "$WIN_PYTHON_EXE" -m pip wheel . -w dist --no-build-isolation \
+            -C cmake.define.Python3_EXECUTABLE="$WIN_PYTHON_EXE" \
+            -C cmake.define.Python3_FIND_STRATEGY=LOCATION \
+            -C cmake.define.Python3_FIND_REGISTRY=NEVER
+
+      - name: Repair wheel with delvewheel
+        run: |
+          export WIN_PYTHON_EXE=$(cygpath -u "$pythonLocation/python.exe")
+          MINGW_BIN_WIN=$(cygpath -w "$MINGW_PREFIX/bin")
+          "$WIN_PYTHON_EXE" -m delvewheel repair dist/*.whl -w wheelhouse --add-path "$MINGW_BIN_WIN"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: monero-python-win-amd64
-          path: dist/
+          path: wheelhouse/*.whl

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   report-coverage-linux:
-    if: github.repository == 'everoddandeven/monero-python'
+    if: github.repository == 'everoddandeven/monero-python' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  build-deb:
+    uses: ./.github/workflows/build-deb.yml
+
+  build-macos:
+    uses: ./.github/workflows/build-macos.yml
+
+  build-windows:
+    uses: ./.github/workflows/build-windows.yml
+
+  release:
+    name: Publish draft release
+    needs: [build-deb, build-macos, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download deb packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: python3-monero_*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Download macos wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: monero-macos-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Download windows wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: monero-python-win-amd64
+          path: release-assets
+          merge-multiple: true
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --draft \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            release-assets/*.deb release-assets/*.whl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     runs-on: ubuntu-24.04
@@ -21,6 +24,20 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Determine monero submodule version
+        run: git submodule status --recursive > .monero-submodule-version
+
+      - name: Cache monero/monero-cpp build
+        id: cache-monero
+        uses: actions/cache@v4
+        with:
+          path: |
+            external/monero-cpp/external/monero-project/build
+            external/monero-cpp/build
+          key: monero-build-linux-${{ hashFiles('.monero-submodule-version') }}
+          restore-keys: |
+            monero-build-linux-
+
       - name: Install dependencies
         run: |
           sudo apt update
@@ -29,11 +46,11 @@ jobs:
 
       - name: Install expat
         run: |
-          wget https://github.com/libexpat/libexpat/releases/download/R_2_4_8/expat-2.4.8.tar.bz2
-          tar -xf expat-2.4.8.tar.bz2
-          sudo rm expat-2.4.8.tar.bz2
-          cd expat-2.4.8
-          ./configure --enable-static --disable-shared
+          wget https://github.com/libexpat/libexpat/releases/download/R_2_7_1/expat-2.7.1.tar.bz2
+          echo "45c98ae1e9b5127325d25186cf8c511fa814078e9efeae7987a574b482b79b3d  expat-2.7.1.tar.bz2" | sha256sum -c
+          tar -xf expat-2.7.1.tar.bz2
+          cd expat-2.7.1
+          ./configure --enable-static --disable-shared --with-pic
           make
           sudo make install
           cd ../
@@ -41,19 +58,16 @@ jobs:
       - name: Install unbound
         run: |
           wget https://www.nlnetlabs.nl/downloads/unbound/unbound-1.22.0.tar.gz
+          echo "c5dd1bdef5d5685b2cedb749158dd152c52d44f65529a34ac15cd88d4b1b3d43  unbound-1.22.0.tar.gz" | sha256sum -c
           tar xzf unbound-1.22.0.tar.gz
-          sudo apt install -y build-essential
-          sudo apt install -y libssl-dev
-          sudo apt install -y libexpat1-dev
-          sudo apt-get install -y bison
-          sudo apt-get install -y flex
           cd unbound-1.22.0
-          ./configure --with-libexpat=/usr --with-ssl=/usr --enable-static-exe
+          ./configure --with-libexpat=/usr/local --with-ssl=/usr --enable-static --disable-shared --with-pic
           make
           sudo make install
           cd ../
 
       - name: Build monero
+        if: steps.cache-monero.outputs.cache-hit != 'true'
         run: |
           cd external/monero-cpp/external/monero-project
           mkdir -p build/release
@@ -62,7 +76,8 @@ jobs:
           make -j3 wallet cryptonote_protocol
           cd ../../../../../../
 
-      - name: Install monero-cpp
+      - name: Build monero-cpp
+        if: steps.cache-monero.outputs.cache-hit != 'true'
         run: |
           cd external/monero-cpp
           mkdir -p build
@@ -125,6 +140,7 @@ jobs:
           lcov --capture --directory build --ignore-errors mismatch,mismatch,inconsistent,source,source,gcov,gcov --output-file coverage_full.info
           lcov --ignore-errors unused,unused --remove coverage_full.info '/usr/*' '*/external/*' '*/pybind11/*' '*monero-cpp/*' '*monero-project/*' --output-file coverage.info
           sed -i "s|$(pwd)/||g" coverage.info
+          lcov --summary coverage.info
 
       - name: Generate monero-cpp coverage report
         if: always()
@@ -132,6 +148,8 @@ jobs:
           lcov --capture --directory external/monero-cpp/build --ignore-errors mismatch,mismatch,inconsistent,source,source,gcov,gcov --output-file coverage_monero_cpp_full.info
           lcov --ignore-errors unused,unused --extract coverage_monero_cpp_full.info '*/monero-cpp/src/*' --output-file coverage_monero_cpp.info
           sed -i "s|$(pwd)/||g" coverage_monero_cpp.info
+          genhtml coverage_monero_cpp.info --output-directory coverage_monero_cpp_html --ignore-errors mismatch,inconsistent,source,corrupt
+          lcov --summary coverage_monero_cpp.info
 
       - name: Upload coverage report
         if: always()
@@ -142,6 +160,7 @@ jobs:
             coverage.info
             coverage.xml
             coverage_monero_cpp.info
+            coverage_monero_cpp_html/
 
   windows:
     name: windows (pytest)
@@ -157,19 +176,34 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Determine monero submodule version
+        shell: bash
+        run: git submodule status --recursive > .monero-submodule-version
+
+      - name: Cache monero/monero-cpp build
+        id: cache-monero
+        uses: actions/cache@v4
+        with:
+          path: |
+            external/monero-cpp/external/monero-project/build
+            external/monero-cpp/build
+          key: monero-build-windows-${{ hashFiles('.monero-submodule-version') }}
+          restore-keys: |
+            monero-build-windows-
+
       - name: Setup Python 3.13
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
           architecture: 'x64'
 
-      - name: Install pytest
+      - name: Install pytest and dependencies
         shell: bash
         run: |
           python -m pip install pytest pytest-rerunfailures typing_extensions scikit-build-core
 
       - name: Setup MSYS2 MINGW64
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           msystem: MINGW64
           update: true
@@ -191,25 +225,25 @@ jobs:
             wget
 
       - name: Install ICU v75.1
-        shell: msys2 {0}
         run: |
           wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-75.1-2-any.pkg.tar.zst
+          echo "bf57882d43efcdfd746463613ea982c69b64aa4ba9bed4cb24c02a81ad06c3a9  mingw-w64-x86_64-icu-75.1-2-any.pkg.tar.zst" | sha256sum -c
           pacman -U --noconfirm mingw-w64-x86_64-icu-75.1-2-any.pkg.tar.zst
 
       - name: Install boost v1.87.0
-        shell: msys2 {0}
         run: |
           wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-boost-1.87.0-3-any.pkg.tar.zst
+          echo "241919a5885a9270d0e0937e71cf5e146c2a8cabecc2714f09248350181cb1b6  mingw-w64-x86_64-boost-1.87.0-3-any.pkg.tar.zst" | sha256sum -c
           pacman -U --noconfirm mingw-w64-x86_64-boost-1.87.0-3-any.pkg.tar.zst
 
-      - name: Install pybind11 v2.13.1
-        shell: msys2 {0}
+      - name: Install pybind11 v2.13.6
         run: |
           wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-pybind11-2.13.6-2-any.pkg.tar.zst
+          echo "5b56ad87bc544336b2d51edb8bb0614f46542571362daf4d7e53bf23120175a1  mingw-w64-x86_64-pybind11-2.13.6-2-any.pkg.tar.zst" | sha256sum -c
           pacman -U --noconfirm mingw-w64-x86_64-pybind11-2.13.6-2-any.pkg.tar.zst
 
       - name: Build monero
-        shell: msys2 {0}
+        if: steps.cache-monero.outputs.cache-hit != 'true'
         run: |
           cd external/monero-cpp/external/monero-project
           mkdir -p build/release
@@ -226,7 +260,7 @@ jobs:
             make wallet cryptonote_protocol
 
       - name: Build monero-cpp
-        shell: msys2 {0}
+        if: steps.cache-monero.outputs.cache-hit != 'true'
         run: |
           cd external/monero-cpp
           mkdir -p build
@@ -235,11 +269,10 @@ jobs:
           cmake --build .
 
       - name: Build monero-python
-        shell: msys2 {0}
         run: |
           mkdir -p build
           cd build
-          export WIN_PYTHON_EXE=$(cygpath -u "$PYTHON")
+          export WIN_PYTHON_EXE=$(cygpath -u "$pythonLocation/python.exe")
           cmake .. -DPython3_EXECUTABLE="$WIN_PYTHON_EXE" \
             -DPython3_FIND_STRATEGY=LOCATION \
             -DPython3_FIND_REGISTRY=NEVER
@@ -262,14 +295,33 @@ jobs:
           python -m pytest -m unit
 
   macos:
-    runs-on: macos-15
-    name: macos (pytest)
+    name: ${{ matrix.os }} (pytest)
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-15, macos-15-intel]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Determine monero submodule version
+        run: git submodule status --recursive > .monero-submodule-version
+
+      - name: Cache monero/monero-cpp build
+        id: cache-monero
+        uses: actions/cache@v4
+        with:
+          path: |
+            external/monero-cpp/external/monero-project/build
+            external/monero-cpp/build
+          key: monero-build-macos-${{ matrix.os }}-${{ hashFiles('.monero-submodule-version') }}
+          restore-keys: |
+            monero-build-macos-${{ matrix.os }}-
 
       - name: Install dependencies
         run: |
@@ -283,6 +335,7 @@ jobs:
           pip3 install pybind11==2.13.6 pybind11-stubgen --break-system-packages
 
       - name: Build monero
+        if: steps.cache-monero.outputs.cache-hit != 'true'
         run: |
           cd external/monero-cpp/external/monero-project
           mkdir -p build/release
@@ -291,7 +344,8 @@ jobs:
           make -j3 wallet cryptonote_protocol
           cd ../../../../../../
 
-      - name: Install monero-cpp
+      - name: Build monero-cpp
+        if: steps.cache-monero.outputs.cache-hit != 'true'
         run: |
           cd external/monero-cpp
           mkdir -p build

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     python3 python3-pip python3-all python3-pybind11 python3-pytest python3-pytest-rerunfailures \
     ccache doxygen graphviz git curl autoconf libtool gperf nettle-dev libevent-dev \
     debhelper bison flex wget \
+ && ldconfig \
  && rm -rf /var/lib/apt/lists/*
 
 RUN . /etc/os-release && \
@@ -24,17 +25,19 @@ RUN . /etc/os-release && \
         pip3 install scikit-build-core --break-system-packages; \
     fi
 
-RUN wget https://github.com/libexpat/libexpat/releases/download/R_2_4_8/expat-2.4.8.tar.bz2 \
- && tar -xf expat-2.4.8.tar.bz2 \
- && cd expat-2.4.8 \
- && ./configure --enable-static --disable-shared \
+RUN wget https://github.com/libexpat/libexpat/releases/download/R_2_7_1/expat-2.7.1.tar.bz2 \
+ && echo "45c98ae1e9b5127325d25186cf8c511fa814078e9efeae7987a574b482b79b3d  expat-2.7.1.tar.bz2" | sha256sum -c \
+ && tar -xf expat-2.7.1.tar.bz2 \
+ && cd expat-2.7.1 \
+ && ./configure --enable-static --disable-shared --with-pic \
  && make -j$(nproc) && make install \
- && cd .. && rm -rf expat-2.4.8*
+ && cd .. && rm -rf expat-2.7.1*
 
 RUN wget https://www.nlnetlabs.nl/downloads/unbound/unbound-1.22.0.tar.gz \
+ && echo "c5dd1bdef5d5685b2cedb749158dd152c52d44f65529a34ac15cd88d4b1b3d43  unbound-1.22.0.tar.gz" | sha256sum -c \
  && tar xzf unbound-1.22.0.tar.gz \
  && cd unbound-1.22.0 \
- && ./configure --with-libexpat=/usr --with-ssl=/usr --enable-static-exe \
+ && ./configure --with-libexpat=/usr/local --with-ssl=/usr --enable-static --disable-shared --with-pic \
  && make -j$(nproc) && make install \
  && cd .. && rm -rf unbound-1.22.0*
 

--- a/debian/bookworm/control
+++ b/debian/bookworm/control
@@ -3,7 +3,7 @@ Section: python
 Priority: optional
 Maintainer: everoddandeven <everoddandeven@protonmail.com>
 Build-Depends: build-essential, cmake, pkg-config, debhelper, python3-all, libssl-dev, libzmq3-dev, libunbound-dev, libsodium-dev, libunwind8-dev, liblzma-dev, libreadline6-dev, libexpat1-dev, libpgm-dev, qttools5-dev-tools, libhidapi-dev, libusb-1.0-0-dev, libprotobuf-dev, protobuf-compiler, libudev-dev, libboost-chrono-dev, libboost-date-time-dev, libboost-filesystem-dev, libboost-locale-dev, libboost-program-options-dev, libboost-regex-dev libboost-serialization-dev, libboost-system-dev, libboost-thread-dev, python3, ccache, doxygen, graphviz, nettle-dev, libevent-dev, python3-pip, python3-pybind11, python3-pytest, pybind11-dev
-Depends: libunbound8, libprotobuf23, libboost-chrono1.74.0, libboost-filesystem1.74.0, libboost-program-options1.74.0, libboost-regex1.74.0, libboost-serialization1.74.0, libboost-thread1.74.0, libhidapi-libusb0
+Depends: ${shlibs:Depends}
 Standards-Version: 4.5.0
 Homepage: https://github.com/everoddandeven/monero-python
 Rules-Requires-Root: no

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,11 @@
+Source: python3-monero
+Section: python
+Priority: optional
+Maintainer: everoddandeven <everoddandeven@protonmail.com>
+Standards-Version: 4.5.0
+
+Package: python3-monero
+Architecture: any
+Depends: ${shlibs:Depends}
+Description: Python bindings for monero-cpp
+ This package provides Python 3 bindings for the monero-cpp library using pybind11.

--- a/debian/jammy/control
+++ b/debian/jammy/control
@@ -3,7 +3,7 @@ Section: python
 Priority: optional
 Maintainer: everoddandeven <everoddandeven@protonmail.com>
 Build-Depends: build-essential, cmake, pkg-config, debhelper, python3-all, libssl-dev, libzmq3-dev, libunbound-dev, libsodium-dev, libunwind8-dev, liblzma-dev, libreadline6-dev, libexpat1-dev, libpgm-dev, qttools5-dev-tools, libhidapi-dev, libusb-1.0-0-dev, libprotobuf-dev, protobuf-compiler, libudev-dev, libboost-chrono-dev, libboost-date-time-dev, libboost-filesystem-dev, libboost-locale-dev, libboost-program-options-dev, libboost-regex-dev libboost-serialization-dev, libboost-system-dev, libboost-thread-dev, python3, ccache, doxygen, graphviz, nettle-dev, libevent-dev, python3-pip, python3-pybind11, python3-pytest, pybind11-dev
-Depends: libunbound8, libprotobuf23, libboost-chrono1.74.0, libboost-filesystem1.74.0, libboost-program-options1.74.0, libboost-regex1.74.0, libboost-serialization1.74.0, libboost-thread1.74.0, libhidapi-libusb0
+Depends: ${shlibs:Depends}
 Standards-Version: 4.5.0
 Homepage: https://github.com/everoddandeven/monero-python
 Rules-Requires-Root: no

--- a/debian/noble/control
+++ b/debian/noble/control
@@ -3,7 +3,7 @@ Section: python
 Priority: optional
 Maintainer: everoddandeven <everoddandeven@protonmail.com>
 Build-Depends: build-essential, cmake, pkg-config, debhelper, python3-all, libssl-dev, libzmq3-dev, libunbound-dev, libsodium-dev, libunwind8-dev, liblzma-dev, libreadline6-dev, libexpat1-dev, libpgm-dev, qttools5-dev-tools, libhidapi-dev, libusb-1.0-0-dev, libprotobuf-dev, protobuf-compiler, libudev-dev, libboost-chrono-dev, libboost-date-time-dev, libboost-filesystem-dev, libboost-locale-dev, libboost-program-options-dev, libboost-regex-dev libboost-serialization-dev, libboost-system-dev, libboost-thread-dev, python3, ccache, doxygen, graphviz, nettle-dev, libevent-dev, python3-pip, python3-pybind11, python3-pytest, pybind11-dev
-Depends: libunbound8, libprotobuf32t64, libboost-chrono1.83.0, libboost-filesystem1.83.0, libboost-program-options1.83.0, libboost-regex1.83.0, libboost-serialization1.83.0, libboost-thread1.83.0, libhidapi-libusb0
+Depends: ${shlibs:Depends}
 Standards-Version: 4.5.0
 Homepage: https://github.com/everoddandeven/monero-python
 Rules-Requires-Root: no

--- a/debian/trixie/control
+++ b/debian/trixie/control
@@ -3,7 +3,7 @@ Section: python
 Priority: optional
 Maintainer: everoddandeven <everoddandeven@protonmail.com>
 Build-Depends: build-essential, cmake, pkg-config, debhelper, python3-all, libssl-dev, libzmq3-dev, libunbound-dev, libsodium-dev, libunwind8-dev, liblzma-dev, libreadline6-dev, libexpat1-dev, libpgm-dev, qttools5-dev-tools, libhidapi-dev, libusb-1.0-0-dev, libprotobuf-dev, protobuf-compiler, libudev-dev, libboost-chrono-dev, libboost-date-time-dev, libboost-filesystem-dev, libboost-locale-dev, libboost-program-options-dev, libboost-regex-dev libboost-serialization-dev, libboost-system-dev, libboost-thread-dev, python3, ccache, doxygen, graphviz, nettle-dev, libevent-dev, python3-pip, python3-pybind11, python3-pytest, pybind11-dev
-Depends: libunbound8, libprotobuf32t64, libboost-chrono1.83.0, libboost-filesystem1.83.0, libboost-program-options1.83.0, libboost-regex1.83.0, libboost-serialization1.83.0, libboost-thread1.83.0, libhidapi-libusb0
+Depends: ${shlibs:Depends}
 Standards-Version: 4.5.0
 Homepage: https://github.com/everoddandeven/monero-python
 Rules-Requires-Root: no

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -46,7 +46,7 @@ else
 fi
 cd ../../../../
 
-# build libmonero-cpp shared library
+# build libmonero-cpp library
 mkdir -p build &&
 cd build &&
 cmake .. &&
@@ -65,6 +65,28 @@ CONTROL_FILE="build/${PACKAGE_NAME}/DEBIAN/control"
 if [ -f "$CONTROL_FILE" ]; then
     echo "Patching control file architecture to: ${ARCH}"
     sed -i "s/^Architecture: .*/Architecture: ${ARCH}/" "$CONTROL_FILE"
+
+    echo "Computing runtime library dependencies with dpkg-shlibdeps"
+    SO_FILES=$(find "build/${PACKAGE_NAME}/usr/lib/python3/dist-packages" -maxdepth 1 -name "*.so")
+    if [ -z "$SO_FILES" ]; then
+        echo "ERROR: no compiled .so found in package tree for shlibdeps analysis" >&2
+        exit 1
+    fi
+
+    SHLIBS_OUT=$(mktemp)
+    dpkg-shlibdeps -O --ignore-missing-info $SO_FILES > "$SHLIBS_OUT"
+    SHLIBS_DEPENDS=$(sed -n 's/^shlibs:Depends=//p' "$SHLIBS_OUT")
+    rm -f "$SHLIBS_OUT"
+
+    if [ -z "$SHLIBS_DEPENDS" ]; then
+        echo "ERROR: dpkg-shlibdeps produced no dependency information" >&2
+        exit 1
+    fi
+
+    echo "Computed dependencies: ${SHLIBS_DEPENDS}"
+    CONTROL_CONTENT=$(cat "$CONTROL_FILE")
+    CONTROL_CONTENT="${CONTROL_CONTENT//\$\{shlibs:Depends\}/$SHLIBS_DEPENDS}"
+    printf '%s\n' "$CONTROL_CONTENT" > "$CONTROL_FILE"
 else
     echo "WARNING: control file not found at: $CONTROL_FILE"
 fi

--- a/tests/test_monero_wallet_common.py
+++ b/tests/test_monero_wallet_common.py
@@ -718,6 +718,7 @@ class BaseTestMoneroWallet(BaseTestClass):
     @pytest.mark.skipif(TestUtils.TEST_RELAYS is False, reason="TEST_RELAYS disabled")
     @pytest.mark.skipif(TestUtils.TEST_NOTIFICATIONS is False, reason="TEST_NOTIFICATIONS disabled")
     @pytest.mark.skipif(TestUtils.LITE_MODE, reason="LITE_MODE enabled")
+    @pytest.mark.flaky(reruns=3, reruns_delay=5)
     def test_update_locked_different_accounts_split(self, daemon: MoneroDaemonRpc, wallet: MoneroWallet) -> None:
         config: MoneroTxConfig = MoneroTxConfig()
         config.address = wallet.get_subaddress(1, 0).address


### PR DESCRIPTION
* Cache monero/monero-cpp builds across linux/windows/macos jobs, keyed on the submodule commit (test.yml, build-macos.yml, build-windows.yml)
* Add GHA docker buildx layer cache to build-deb.yml
* Guard codacy.yml against running on a failed/cancelled Tests run
* Scope workflow permissions to contents: read by default
* Build Windows package as a real wheel (pip wheel + delvewheel) instead of a raw dist folder
* Repair macOS wheels with delocate to bundle Homebrew dylibs
* Compute .deb runtime dependencies with dpkg-shlibdeps instead of a hand-maintained per-codename version list
* Bump expat/unbound with checksum verification in Dockerfile.linux
* Add monero-cpp coverage HTML report and summary tables to test.yml
* Pin msys2/setup-msys2 to an exact commit and drop redundant shell: msys2 {0} overrides